### PR TITLE
카카오맵 데이터 저장, 음식점 엔티티 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 .env
+kakao_map_json_file.json
 
 
 ### STS ###

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,14 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/likelion/domain/entity/Restaurant.java
+++ b/src/main/java/likelion/domain/entity/Restaurant.java
@@ -16,7 +16,7 @@ public class Restaurant {
     //리뷰 만들 때 외래 키로 사용.
     @Id @Column(name="kakao_place_id", nullable = false) Long kakaoPlaceId;
 
-    @Column(name="resaurant_name")
+    @Column(name="restaurant_name")
     String restaurantName;
 
     @Column(name="category") String category;
@@ -40,7 +40,7 @@ public class Restaurant {
         return kakaoPlaceId;
     }
 
-    public String getName() {
+    public String getRestaurantName() {
         return restaurantName;
     }
 

--- a/src/main/java/likelion/domain/entity/Restaurant.java
+++ b/src/main/java/likelion/domain/entity/Restaurant.java
@@ -1,0 +1,118 @@
+package likelion.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "restaurant")
+@RequiredArgsConstructor
+public class Restaurant {
+    //id를 자동생성 말고 url 뒤에 자른 걸로 쓰고.
+    //리뷰 만들 때 외래 키로 사용.
+    @Id @Column(name="kakao_place_id", nullable = false) Long kakaoPlaceId;
+
+    @Column(name="resaurant_name")
+    String restaurantName;
+
+    @Column(name="category") String category;
+
+    @Column(name="rating")
+    BigDecimal rating;
+
+    @Column(name="rating_count") Integer ratingCount;
+
+    @Column(name="review_count") Integer reviewCount;
+
+    @Column(name="road_address") String roadAddress;
+
+    @Column(name="number_address") String numberAddress;
+
+    @Column(name="business_time") String businessTime;
+
+    @Column(name="kakao_url") String kakaoUrl;
+
+    public Long getKakaoPlaceId() {
+        return kakaoPlaceId;
+    }
+
+    public String getName() {
+        return restaurantName;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public BigDecimal getRating() {
+        return rating;
+    }
+
+    public Integer getRatingCount() {
+        return ratingCount;
+    }
+
+    public Integer getReviewCount() {
+        return reviewCount;
+    }
+
+    public String getRoadAddress() {
+        return roadAddress;
+    }
+
+    public String getNumberAddress() {
+        return numberAddress;
+    }
+
+    public String getBusinessTime() {
+        return businessTime;
+    }
+
+    public String getKakaoUrl() {
+        return kakaoUrl;
+    }
+
+    public void setRestaurantName(String restaurantName) {
+        this.restaurantName = restaurantName;
+    }
+
+    public void setKakaoPlaceId(Long kakaoPlaceId) {
+        this.kakaoPlaceId = kakaoPlaceId;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public void setRating(BigDecimal rating) {
+        this.rating = rating;
+    }
+
+    public void setRatingCount(Integer ratingCount) {
+        this.ratingCount = ratingCount;
+    }
+
+    public void setReviewCount(Integer reviewCount) {
+        this.reviewCount = reviewCount;
+    }
+
+    public void setRoadAddress(String roadAddress) {
+        this.roadAddress = roadAddress;
+    }
+
+    public void setNumberAddress(String numberAddress) {
+        this.numberAddress = numberAddress;
+    }
+
+    public void setBusinessTime(String businessTime) {
+        this.businessTime = businessTime;
+    }
+
+    public void setKakaoUrl(String kakaoUrl) {
+        this.kakaoUrl = kakaoUrl;
+    }
+}

--- a/src/main/java/likelion/jsondata/SeedRunner.java
+++ b/src/main/java/likelion/jsondata/SeedRunner.java
@@ -1,0 +1,34 @@
+package likelion.jsondata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import likelion.domain.entity.Restaurant;
+import likelion.jsondata.mapper.RestaurantMapper;
+import likelion.jsondata.record.RestaurantJson;
+import likelion.repository.RestaurantRepository;
+import lombok.*;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Component
+@RequiredArgsConstructor
+public class SeedRunner implements CommandLineRunner {
+    private final ObjectMapper om;
+    private final RestaurantMapper mapper;
+    private final RestaurantRepository repository;
+
+    @Override
+    public void run(String... args) throws Exception{
+        if(args.length==0) return;
+        Path path = Paths.get(args[0]);
+        RestaurantJson[] arr = om.readValue(Files.readAllBytes(path), RestaurantJson[].class);
+        //중복 기준은 PK 그 url 짤라서 만든 거
+        for(RestaurantJson j : arr){
+            Restaurant r = mapper.map(j);
+            repository.save(r);
+        }
+    }
+}

--- a/src/main/java/likelion/jsondata/mapper/RestaurantMapper.java
+++ b/src/main/java/likelion/jsondata/mapper/RestaurantMapper.java
@@ -1,0 +1,47 @@
+package likelion.jsondata.mapper;
+
+import likelion.domain.entity.Restaurant;
+import likelion.jsondata.record.RestaurantJson;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+@Component
+public class RestaurantMapper {
+    public Restaurant map(RestaurantJson j){
+        Restaurant r = new Restaurant();
+        r.setRestaurantName(nvl(j.가게이름()));
+        r.setCategory(j.카테고리());
+        r.setBusinessTime(j.영업시간());
+        r.setRatingCount(parseInt(j.평점건수()));
+        r.setRating(parseDecimal(j.평점()));
+        r.setReviewCount(parseInt(j.리뷰수()));
+        r.setKakaoUrl(j.상세정보링크());
+        r.setNumberAddress(j.지번());
+        r.setRoadAddress(j.주소());
+        r.setKakaoPlaceId(makeKakaoId(j.상세정보링크()));
+
+        return r;
+    }
+
+    private Long makeKakaoId(String url){
+        return Long.valueOf(url.replaceAll("\\D+",""));
+    }
+
+    private BigDecimal parseDecimal(String s){
+        if (s == null) return null;
+        s = s.trim();
+        if (s.isEmpty()) return null;
+        s = s.replaceAll("[^0-9.]", ""); // "4.7점" 같은 경우 대비
+        if (s.isEmpty()) return null;
+        return new BigDecimal(s);
+    }
+
+    private Integer parseInt(String s){
+        if (s == null) return null;
+        s = s.replaceAll("\\D+", ""); // "(30)" → "30"
+        return s.isEmpty() ? null : Integer.valueOf(s);
+    }
+
+    private String nvl(String s){ return (s == null || s.isBlank()) ? null : s.trim(); }
+}

--- a/src/main/java/likelion/jsondata/record/RestaurantJson.java
+++ b/src/main/java/likelion/jsondata/record/RestaurantJson.java
@@ -1,0 +1,8 @@
+package likelion.jsondata.record;
+
+public record RestaurantJson(
+        String 가게이름, String 카테고리, String 평점,
+        String 평점건수, String 리뷰수, String 주소,
+        String 지번, String 영업시간,
+        String 상세정보링크
+) { }

--- a/src/main/java/likelion/repository/RestaurantRepository.java
+++ b/src/main/java/likelion/repository/RestaurantRepository.java
@@ -1,0 +1,11 @@
+package likelion.repository;
+
+import likelion.domain.entity.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+    /**
+     * 인터페이스
+     */
+}

--- a/src/test/java/likelion/kakaomapData/KakaoMapDataInputTest.java
+++ b/src/test/java/likelion/kakaomapData/KakaoMapDataInputTest.java
@@ -1,17 +1,21 @@
 package likelion.kakaomapData;
 
 import likelion.domain.entity.Restaurant;
+import likelion.jsondata.mapper.RestaurantMapper;
+import likelion.jsondata.record.RestaurantJson;
 import likelion.repository.RestaurantRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional // 테스트 후 롤백
@@ -19,6 +23,24 @@ class KakaoMapDataInputTest {
 
     @Autowired
     RestaurantRepository repository;
+
+    @Autowired
+    RestaurantMapper mapper;
+
+    private Restaurant newR(Long id, String name) {
+        Restaurant r = new Restaurant();
+        r.setKakaoPlaceId(id);               // @Id
+        r.setRestaurantName(name);
+        r.setCategory("카페");
+        r.setRoadAddress("주소");
+        r.setNumberAddress("지번");
+        r.setKakaoUrl("https://place.map.kakao.com/" + id);
+        r.setBusinessTime("매일 10:00 ~ 22:00");
+        r.setRating(new BigDecimal("4.4"));
+        r.setRatingCount(7);
+        r.setReviewCount(6);
+        return r;
+    }
 
     @Test
     @DisplayName("Restaurant 저장/조회 기본 동작")
@@ -43,5 +65,54 @@ class KakaoMapDataInputTest {
         List<Restaurant> all = repository.findAll();
         assertThat(all).isNotEmpty();
         assertThat(all.get(0).getName()).isEqualTo("테스트 식당");
+    }
+
+    @Test
+    @DisplayName("같은 kakaoPlaceId로 2번 save해도 row는 1개(두 번째가 UPDATE)")
+    void duplicateId_savedOnce() {
+        // given
+        Long dupId = 243846109L;
+        var first  = newR(dupId, "코이노커피");
+        var second = newR(dupId, "코이노커피(중복)");
+
+        // when
+        repository.save(first);      // INSERT
+        repository.save(second);     // UPDATE(merge)
+        repository.flush();
+
+        // then
+        assertThat(repository.count()).isEqualTo(1L);
+        var found = repository.findById(dupId).orElseThrow();
+        assertThat(found.getName()).isEqualTo("코이노커피(중복)");
+    }
+
+    @Test
+    @DisplayName("Mapper 경로로도 중복 저장 시 최종 1건 + 마지막 값으로 갱신")
+    void duplicateViaMapper_updatesLastOne() {
+        // given
+        RestaurantJson j1 = new RestaurantJson(
+                "코이노커피", "카페", "5.0", "23", "155",
+                "도로", "지번", "영업",
+                "https://place.map.kakao.com/243846109"
+        );
+        RestaurantJson j2 = new RestaurantJson(
+                "코이노커피(중복)", "카페", "4.0", "10", "100",
+                "도로", "지번", "영업",
+                "https://place.map.kakao.com/243846109" // 동일 ID
+        );
+
+        var r1 = mapper.map(j1);
+        var r2 = mapper.map(j2);
+
+        // when
+        repository.save(r1);         // INSERT
+        repository.save(r2);         // UPDATE
+        repository.flush();
+
+        // then
+        assertThat(repository.count()).isEqualTo(1L);
+        var found = repository.findById(243846109L).orElseThrow();
+        assertThat(found.getName()).isEqualTo("코이노커피(중복)");
+        assertThat(found.getRating()).isEqualByComparingTo(new BigDecimal("4.0")); // 마지막 값으로 덮였는지 체크
     }
 }

--- a/src/test/java/likelion/kakaomapData/KakaoMapDataInputTest.java
+++ b/src/test/java/likelion/kakaomapData/KakaoMapDataInputTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -64,7 +63,7 @@ class KakaoMapDataInputTest {
         // then
         List<Restaurant> all = repository.findAll();
         assertThat(all).isNotEmpty();
-        assertThat(all.get(0).getName()).isEqualTo("테스트 식당");
+        assertThat(all.get(0).getRestaurantName()).isEqualTo("테스트 식당");
     }
 
     @Test
@@ -83,7 +82,7 @@ class KakaoMapDataInputTest {
         // then
         assertThat(repository.count()).isEqualTo(1L);
         var found = repository.findById(dupId).orElseThrow();
-        assertThat(found.getName()).isEqualTo("코이노커피(중복)");
+        assertThat(found.getRestaurantName()).isEqualTo("코이노커피(중복)");
     }
 
     @Test
@@ -112,7 +111,7 @@ class KakaoMapDataInputTest {
         // then
         assertThat(repository.count()).isEqualTo(1L);
         var found = repository.findById(243846109L).orElseThrow();
-        assertThat(found.getName()).isEqualTo("코이노커피(중복)");
+        assertThat(found.getRestaurantName()).isEqualTo("코이노커피(중복)");
         assertThat(found.getRating()).isEqualByComparingTo(new BigDecimal("4.0")); // 마지막 값으로 덮였는지 체크
     }
 }

--- a/src/test/java/likelion/kakaomapData/KakaoMapDataInputTest.java
+++ b/src/test/java/likelion/kakaomapData/KakaoMapDataInputTest.java
@@ -1,0 +1,47 @@
+package likelion.kakaomapData;
+
+import likelion.domain.entity.Restaurant;
+import likelion.repository.RestaurantRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional // 테스트 후 롤백
+class KakaoMapDataInputTest {
+
+    @Autowired
+    RestaurantRepository repository;
+
+    @Test
+    @DisplayName("Restaurant 저장/조회 기본 동작")
+    void saveAndFind() {
+        // given
+        Restaurant r = new Restaurant();   // 기본 생성자 + setter 사용
+        r.setRestaurantName("테스트 식당");
+        r.setCategory("한식");
+        r.setRoadAddress("경기 안산시 상록구 학사1길 1");
+        r.setNumberAddress("사동 111-1");
+        r.setKakaoUrl("https://place.map.kakao.com/123456");
+        r.setKakaoPlaceId(123456L);               // Long/nullable 권장
+        r.setBusinessTime("09:00~21:00");
+        r.setReviewCount(10);                      // Integer(래퍼) 권장
+        r.setRatingCount(5);
+        r.setRating(new BigDecimal("4.5"));       // BigDecimal 권장
+
+        // when
+        repository.save(r);
+
+        // then
+        List<Restaurant> all = repository.findAll();
+        assertThat(all).isNotEmpty();
+        assertThat(all.get(0).getName()).isEqualTo("테스트 식당");
+    }
+}


### PR DESCRIPTION
## Summary
- json 데이터 읽어서 DB 저장.
- 공백, 숫자가 아닌 (30) 같은 내용 처리하는 로직
- dotenv 디펜던시 추가해줘야 .env 파일 읽을 수 있음
- 테스트코드 작성

## Screenshot (optional)


## Notes (optional)
`./gradlew bootRun --args='kakao_map_json_file.json' `(뒤에 '경로' 넣어줘야함)