### PR TITLE
게시글에 댓글 수 기록/조회

### DIFF
--- a/src/main/java/likelion/domain/entity/Post.java
+++ b/src/main/java/likelion/domain/entity/Post.java
@@ -47,6 +47,10 @@ public class Post {
     @OrderBy("id asc")
     private List<Comment> comments;
 
+    @Column(name = "comment_count", nullable = false)
+    @Builder.Default
+    private Integer commentCount = 0;
+
     //타임스탬프 설정
     @PrePersist
     protected void onCreate(){

--- a/src/main/java/likelion/dto/CommentRequestDto.java
+++ b/src/main/java/likelion/dto/CommentRequestDto.java
@@ -4,10 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 import lombok.Setter;
 
 @Schema(description = "댓글 작성 요청")
-@Getter @Setter @NoArgsConstructor
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor
 public class CommentRequestDto {
 
     @Schema(description = "댓글 내용", example = "댓글내용 댓글내용 예시 예시")

--- a/src/main/java/likelion/dto/PostResponseDto.java
+++ b/src/main/java/likelion/dto/PostResponseDto.java
@@ -18,6 +18,7 @@ public class PostResponseDto {
     private final String imageUrl;
     private final String myStoreCategory;
     private final String partnerStoreCategory;
+    private final Integer commentCount;
     private List<CommentResponseDto> comments;
 
     public PostResponseDto(Post post) {
@@ -29,6 +30,7 @@ public class PostResponseDto {
         this.imageUrl = post.getImageUrl();
         this.myStoreCategory = post.getMyStoreCategory() != null ? post.getMyStoreCategory().getDisplayName() : null;
         this.partnerStoreCategory = post.getPartnerStoreCategory() != null ? post.getPartnerStoreCategory().getDisplayName() : null;
+        this.commentCount = post.getCommentCount();
     }
 
     public PostResponseDto(Post post, List<CommentResponseDto> comments) {
@@ -40,6 +42,7 @@ public class PostResponseDto {
         this.imageUrl = post.getImageUrl();
         this.myStoreCategory = post.getMyStoreCategory() != null ? post.getMyStoreCategory().getDisplayName() : null;
         this.partnerStoreCategory = post.getPartnerStoreCategory() != null ? post.getPartnerStoreCategory().getDisplayName() : null;
+        this.commentCount = post.getCommentCount();
         this.comments = comments;
     }
 }

--- a/src/main/java/likelion/repository/PostRepository.java
+++ b/src/main/java/likelion/repository/PostRepository.java
@@ -2,6 +2,8 @@ package likelion.repository;
 
 import likelion.domain.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findAllByOrderByCommentCountDescIdDesc();
 }

--- a/src/main/java/likelion/service/CommentService.java
+++ b/src/main/java/likelion/service/CommentService.java
@@ -37,6 +37,9 @@ public class CommentService {
         // 엔티티 생성. userName이랑 createdAt은 엔티티에서 세팅함
         Comment comment = Comment.builder().post(post).content(content).build();
 
+        post.setCommentCount(post.getCommentCount() + 1);
+        postRepository.saveAndFlush(post);
+
         Comment saved = commentRepository.save(comment);
         return new CommentResponseDto(saved);
     }

--- a/src/main/java/likelion/service/PostService.java
+++ b/src/main/java/likelion/service/PostService.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -88,7 +89,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public List<PostResponseDto> findAll() {
-        return postRepository.findAll().stream()
+        return postRepository.findAllByOrderByCommentCountDescIdDesc().stream()
                 .map(PostResponseDto::new)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/likelion/communityTest/CommentCountTest.java
+++ b/src/test/java/likelion/communityTest/CommentCountTest.java
@@ -1,0 +1,106 @@
+package likelion.communityTest;
+
+import likelion.domain.entity.Post;
+import likelion.dto.CommentRequestDto;
+import likelion.dto.PostCreateRequestDto;
+import likelion.dto.PostResponseDto;
+import likelion.repository.CommentRepository;
+import likelion.repository.PostRepository;
+import likelion.service.CommentService;
+import likelion.service.PostService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.annotation.Commit;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class CommentCountTest {
+
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    private Long postId1;
+    private Long postId2;
+    private Long postId3;
+
+    @BeforeEach
+    @Commit
+    void setUp() throws IOException {
+        // Given
+        PostCreateRequestDto postDto1 = new PostCreateRequestDto();
+        postDto1.setTitle("title1");
+        postDto1.setContent("content1");
+        postId1 = postService.createPost(postDto1, null);
+
+        PostCreateRequestDto postDto2 = new PostCreateRequestDto();
+        postDto2.setTitle("title2");
+        postDto2.setContent("content2");
+        postId2 = postService.createPost(postDto2, null);
+
+        PostCreateRequestDto postDto3 = new PostCreateRequestDto();
+        postDto3.setTitle("title3");
+        postDto3.setContent("content3");
+        postId3 = postService.createPost(postDto3, null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        commentRepository.deleteAllInBatch();
+        postRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @Transactional
+    void commentCountTest() {
+        // When
+        commentService.createComment(postId1, new CommentRequestDto("comment1"));
+        commentService.createComment(postId1, new CommentRequestDto("comment2"));
+        commentService.createComment(postId2, new CommentRequestDto("comment3"));
+
+        // Then
+        Post post1Entity = postRepository.findById(postId1).orElseThrow();
+        PostResponseDto post1 = new PostResponseDto(post1Entity);
+        assertThat(post1.getCommentCount()).isEqualTo(2);
+
+        Post post2Entity = postRepository.findById(postId2).orElseThrow();
+        PostResponseDto post2 = new PostResponseDto(post2Entity);
+        assertThat(post2.getCommentCount()).isEqualTo(1);
+
+        Post post3Entity = postRepository.findById(postId3).orElseThrow();
+        PostResponseDto post3 = new PostResponseDto(post3Entity);
+        assertThat(post3.getCommentCount()).isEqualTo(0);
+    }
+
+    @Test
+    @Transactional
+    void findAllPostsSortedByCommentCountAndId() {
+        // When
+        commentService.createComment(postId2, new CommentRequestDto("comment1"));
+        commentService.createComment(postId2, new CommentRequestDto("comment2"));
+        commentService.createComment(postId3, new CommentRequestDto("comment3"));
+
+        // Then
+        List<PostResponseDto> allPosts = postService.findAll();
+
+        assertThat(allPosts.get(0).getId()).isEqualTo(postId2);
+        assertThat(allPosts.get(1).getId()).isEqualTo(postId3);
+        assertThat(allPosts.get(2).getId()).isEqualTo(postId1);
+    }
+}


### PR DESCRIPTION
## 변경사항
- Post에 댓글 수 기록/조회
- 댓글 수 많은 순서로 조회(리스트)
- 서버 데이터베이스 초기화 필요